### PR TITLE
ARCH-1907 - Remove instances of set-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
           $mappedObjects = $changedObjects | foreach-object { @{ schemaName=$_.schemaName, objectName=$_.objectName, objectType=$_.objectType, operationType=$_.operationType } }
           $objectsAsJson = $mappedObjects | ConvertTo-Json -Compress
 
-          echo "::set-output name=json::$objectsAsJson"
+          echo "json=$objectsAsJson" >> $GITHUB_OUTPUT
 
       - name: Increment snapshots
         # You may also reference the major or major.minor version


### PR DESCRIPTION
# Summary of PR changes
- Updating workflows to comply with GitHub's request to deprecate the `set-output` & `save-state` command in workflows/actions.
- The version has not been incremented on the readme since it will ignore that change


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
